### PR TITLE
Filter out scoped packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ var npmPackageDownloads = require('npm-package-downloads');
 module.exports = function npmUserDownloads(user, period, _notSort) {
   return npmUserPackages(user)
     .then(function (pkgs) {
+      return pkgs.filter(function (p) {
+        return p.name.substr(0, 1) !== '@';
+      });
+    })
+    .then(function (pkgs) {
       return npmPackageDownloads(_.map(pkgs, 'name'), period);
     })
     .then(function (pkgs) {


### PR DESCRIPTION
The npm endpoint used to retrieve download counts doesn't work with scoped packages (or at least not in a way that I can find), and causes the `nud` command to fail if applied to a user who has scoped packages.

Fix this by filtering scoped packages out of the package list before passing to `npm-package-downloads`.